### PR TITLE
Add Animation also when closing per drag

### DIFF
--- a/Sources/PartialSheet/PartialSheetViewModifier.swift
+++ b/Sources/PartialSheet/PartialSheetViewModifier.swift
@@ -247,8 +247,10 @@ struct PartialSheet<SheetContent>: ViewModifier where SheetContent: View {
         // Set the correct anchor point based on the vertical direction of the drag
         if verticalDirection > 1 {
             DispatchQueue.main.async {
-                self.presented = false
-                self.onDismiss?()
+                withAnimation {
+                    self.presented = false
+                    self.onDismiss?()
+                }
             }
         } else if verticalDirection < 0 {
             self.presented = true


### PR DESCRIPTION
Adds the `withAnimation` closure also when closing per drag. I assume it is the intended behaviour?