### PR TITLE
fix crash when dismissKeyboard was call

### DIFF
--- a/Sources/PartialSheet/PartialSheetViewModifier.swift
+++ b/Sources/PartialSheet/PartialSheetViewModifier.swift
@@ -295,7 +295,9 @@ extension PartialSheet {
     /// Dismiss the keyboard
     private func dismissKeyboard() {
         let resign = #selector(UIResponder.resignFirstResponder)
-        UIApplication.shared.sendAction(resign, to: nil, from: nil, for: nil)
+		DispatchQueue.main.async {
+			UIApplication.shared.sendAction(resign, to: nil, from: nil, for: nil)
+		}
     }
 }
 


### PR DESCRIPTION
There will be crash when call dismissKeyboard() on iOS14;
it seem be issue with thread.