### PR TITLE
Configurable min top distance in from sheet to the top of the screen

### DIFF
--- a/Example/PartialSheetExample/Examples/BlurredSheetExample.swift
+++ b/Example/PartialSheetExample/Examples/BlurredSheetExample.swift
@@ -18,7 +18,8 @@ struct BlurredExample: View {
                                        enableCover: true,
                                        coverColor: Color.black.opacity(0.4),
                                        blurEffectStyle: nil,
-                                       cornerRadius: 10
+                                       cornerRadius: 10,
+                                       minTopDistance: 110
     )
         
     var body: some View {

--- a/Sources/PartialSheet/PartialSheetStyle.swift
+++ b/Sources/PartialSheet/PartialSheetStyle.swift
@@ -35,18 +35,23 @@ public struct PartialSheetStyle {
     /// The corner radius of Sheet
     var cornerRadius: CGFloat
     
+    /// Minimum distance between the top of the sheet and the top of the screen
+    var minTopDistance: CGFloat
+    
     public init(background: PartialSheetBackground,
                 handlerBarColor: Color,
                 enableCover: Bool,
                 coverColor: Color,
                 blurEffectStyle: UIBlurEffect.Style? = nil,
-                cornerRadius: CGFloat
+                cornerRadius: CGFloat,
+                minTopDistance: CGFloat
     ) {
         self.background = background
         self.handlerBarColor = handlerBarColor
         self.enableCover = enableCover
         self.coverColor = coverColor
         self.cornerRadius = cornerRadius
+        self.minTopDistance = minTopDistance
     }
 }
 
@@ -66,7 +71,8 @@ extension PartialSheetStyle {
                                  enableCover: true,
                                  coverColor: Color.black.opacity(0.4),
                                  blurEffectStyle: nil,
-                                 cornerRadius: 10
+                                 cornerRadius: 10,
+                                 minTopDistance: 110
         )
     }
 }

--- a/Sources/PartialSheet/PartialSheetViewModifier.swift
+++ b/Sources/PartialSheet/PartialSheetViewModifier.swift
@@ -36,7 +36,7 @@ struct PartialSheet: ViewModifier {
         return max(presenterContentRect.height +
             (UIApplication.shared.windows.first?.safeAreaInsets.bottom ?? 0) -
             sheetContentRect.height - handlerSectionHeight,
-                   110)
+                   style.minTopDistance)
     }
     
     /// The he point for the bottom anchor


### PR DESCRIPTION
PartialSheet currently has a hardcoded min distance between the top of the sheet and the top of the screen (110 points). That's quite a lot on some small screens (e.g. the SE1), so it'd be great to be able to configure the value as needed.