### PR TITLE
Update the partial sheet when it's already being presented

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ A custom SwiftUI modifier to present a Partial Modal Sheet based on his content 
 - \[x] Mac compatibility
 
 #### Nice to have
-- \[ ] ScrcrollView and List compatibility: as soon as Apple adds some API to handle better ScrollViews
+- \[ ] ScrollView and List compatibility: as soon as Apple adds some API to handle better ScrollViews
 
 ## Version 2
 The new version brings a lot of breaking changes and a lot of improvments:

--- a/Sources/PartialSheet/PartialSheetManager.swift
+++ b/Sources/PartialSheet/PartialSheetManager.swift
@@ -38,6 +38,8 @@ public class PartialSheetManager: ObservableObject {
     @Published private(set) var content: AnyView
     /// the onDismiss code runned when the partial sheet is closed
     private(set) var onDismiss: (() -> Void)?
+
+    /// Possibility to customize the slide in/out animation of the partial sheet
     public var defaultAnimation: Animation = .interpolatingSpring(stiffness: 300.0, damping: 30.0, initialVelocity: 10.0)
 
     public init() {

--- a/Sources/PartialSheet/PartialSheetViewModifier.swift
+++ b/Sources/PartialSheet/PartialSheetViewModifier.swift
@@ -192,7 +192,7 @@ extension PartialSheet {
                 }
                 .edgesIgnoringSafeArea(.vertical)
                 .onTapGesture {
-                    withAnimation(.interpolatingSpring(stiffness: 300.0, damping: 30.0, initialVelocity: 10.0)) {
+                    withAnimation(manager.defaultAnimation) {
                         self.manager.isPresented = false
                         self.dismissKeyboard()
                         self.manager.onDismiss?()
@@ -223,7 +223,7 @@ extension PartialSheet {
                     Spacer()
                 }
                 .onPreferenceChange(SheetPreferenceKey.self, perform: { (prefData) in
-                    withAnimation(.interpolatingSpring(stiffness: 300.0, damping: 30.0, initialVelocity: 10.0)) {
+                    withAnimation(manager.defaultAnimation) {
                         self.sheetContentRect = prefData.first?.bounds ?? .zero
                     }
                 })
@@ -274,14 +274,14 @@ extension PartialSheet {
         // Set the correct anchor point based on the vertical direction of the drag
         if verticalDirection > 1 {
             DispatchQueue.main.async {
-                withAnimation(.interpolatingSpring(stiffness: 300.0, damping: 30.0, initialVelocity: 10.0)) {
+                withAnimation(manager.defaultAnimation) {
                     dragOffset = 0
                     self.manager.isPresented = false
                     self.manager.onDismiss?()
                 }
             }
         } else if verticalDirection < 0 {
-            withAnimation(.interpolatingSpring(stiffness: 300.0, damping: 30.0, initialVelocity: 10.0)) {
+            withAnimation(manager.defaultAnimation) {
                 dragOffset = 0
                 self.manager.isPresented = true
             }
@@ -298,7 +298,7 @@ extension PartialSheet {
                 closestPosition = bottomAnchor
             }
             
-            withAnimation(.interpolatingSpring(stiffness: 300.0, damping: 30.0, initialVelocity: 10.0)) {
+            withAnimation(manager.defaultAnimation) {
                 dragOffset = 0
                 self.manager.isPresented = (closestPosition == topAnchor)
                 if !manager.isPresented {
@@ -318,7 +318,7 @@ extension PartialSheet {
         if let rect: CGRect = notification.userInfo![endFrame] as? CGRect {
             let height = rect.height
             let bottomInset = UIApplication.shared.windows.first?.safeAreaInsets.bottom
-            withAnimation(.interpolatingSpring(stiffness: 300.0, damping: 30.0, initialVelocity: 10.0)) {
+            withAnimation(manager.defaultAnimation) {
                 self.keyboardOffset = height - (bottomInset ?? 0)
             }
         }
@@ -327,7 +327,7 @@ extension PartialSheet {
     /// Remove the keyboard offset
     private func keyboardHide(notification: Notification) {
         DispatchQueue.main.async {
-            withAnimation(.interpolatingSpring(stiffness: 300.0, damping: 30.0, initialVelocity: 10.0)) {
+            withAnimation(manager.defaultAnimation) {
                 self.keyboardOffset = 0
             }
         }


### PR DESCRIPTION
Instead of presenting it again which causes issues on iOS 13. 
could cause the trigger of  "Modifying state during view update, this will cause undefined behavior" on the 
```   swift
.onPreferenceChange(PresenterPreferenceKey.self, perform: { (prefData) in
                        self.presenterContentRect = prefData.first?.bounds ?? .zero
                    })
```
call