### PR TITLE
Fix: Sometimes PartialSheet not showing

### DIFF
--- a/Sources/PartialSheet/PartialSheetManager.swift
+++ b/Sources/PartialSheet/PartialSheetManager.swift
@@ -68,7 +68,7 @@ public class PartialSheetManager: ObservableObject {
 
         self.content = AnyView(content())
         self.onDismiss = onDismiss
-        DispatchQueue.main.async {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.0.5) {
             withAnimation(self.defaultAnimation) {
                 self.isPresented = true
             }


### PR DESCRIPTION
## Root cause

It takes time to create `self.content = AnyView(content())` if  the content view is a heavy one, which could result Runloop bypassess.

## Fix

Added a short delay 