### PR TITLE
Buttons not working in DatePicker with .datePickerStyle(.graphical)

### DIFF
--- a/PartialSheet-Example/Shared/Examples/DatePickerExample.swift
+++ b/PartialSheet-Example/Shared/Examples/DatePickerExample.swift
@@ -24,6 +24,7 @@ struct DatePickerExample: View {
             Spacer()
         }
         .partialSheet(isPresented: $isSheetPresented,
+                      dragGestureSupported: false,
                       content: DatePickerSheetView.init)
         .navigationBarTitle("Date Picker Example")
         .navigationViewStyle(StackNavigationViewStyle())
@@ -48,6 +49,7 @@ struct DatePickerSheetView: View {
             VStack {
                 Text("Settings Panel").font(.headline)
                 DatePicker("Date", selection: $date)
+                    .datePickerStyle(.graphical)
             }
             .padding()
             .frame(height: 270)

--- a/Sources/PartialSheet/PartialSheet/PSManager.swift
+++ b/Sources/PartialSheet/PartialSheet/PSManager.swift
@@ -48,6 +48,11 @@ class PSManager: ObservableObject {
      You can restore the default one calling **restoreDefaultSlideAnimation**
      **/
     var slideAnimation: PSSlideAnimation
+    
+    /**
+     You only need to set false when you  DatePicker with .datePickerStyle(.graphical)
+     */
+    var dragGestureSupported: Bool = true
 
     
     init() {
@@ -63,9 +68,11 @@ class PSManager: ObservableObject {
                                iPhoneStyle: PSIphoneStyle,
                                iPadMacStyle: PSIpadMacStyle,
                                slideAnimation: PSSlideAnimation?,
+                               dragGestureSupported: Bool,
                                content: (() -> T),
                                onDismiss: @escaping (() -> Void)) where T: View {
         self.content = AnyView(content())
+        self.dragGestureSupported = dragGestureSupported
         self.type = type
         self.iPhoneStyle = iPhoneStyle
         self.iPadMacStyle = iPadMacStyle

--- a/Sources/PartialSheet/PartialSheet/PSManagerWrapper.swift
+++ b/Sources/PartialSheet/PartialSheet/PSManagerWrapper.swift
@@ -17,6 +17,7 @@ struct PSManagerWrapper<Parent: View, SheetContent: View>: View {
     let iPhoneStyle: PSIphoneStyle
     let iPadMacStyle: PSIpadMacStyle
     let slideAnimation: PSSlideAnimation?
+    let dragGestureSupported: Bool
     let content: () -> SheetContent
     let parent: Parent
     
@@ -32,6 +33,7 @@ struct PSManagerWrapper<Parent: View, SheetContent: View>: View {
             iPhoneStyle: iPhoneStyle,
             iPadMacStyle: iPadMacStyle,
             slideAnimation: slideAnimation,
+            dragGestureSupported: dragGestureSupported,
             content: content,
             onDismiss: { self.isPresented = false}
         )

--- a/Sources/PartialSheet/PartialSheet/PSViewModifier.swift
+++ b/Sources/PartialSheet/PartialSheet/PSViewModifier.swift
@@ -246,7 +246,7 @@ extension PartialSheet {
                 .cornerRadius(iPhoneStyle.cornerRadius)
                 .shadow(color: Color(.sRGBLinear, white: 0, opacity: 0.13), radius: 10.0)
                 .offset(y: self.sheetPosition)
-                .onTapGesture {}
+//                .onTapGesture {}
                 .gesture(drag)
             }
         }

--- a/Sources/PartialSheet/PartialSheet/PSViewModifier.swift
+++ b/Sources/PartialSheet/PartialSheet/PSViewModifier.swift
@@ -246,8 +246,11 @@ extension PartialSheet {
                 .cornerRadius(iPhoneStyle.cornerRadius)
                 .shadow(color: Color(.sRGBLinear, white: 0, opacity: 0.13), radius: 10.0)
                 .offset(y: self.sheetPosition)
-//                .onTapGesture {}
-                .gesture(drag)
+                .ifIs(manager.dragGestureSupported) { view in
+                    view
+                    .onTapGesture {}
+                    .gesture(drag)
+                }
             }
         }
     }

--- a/Sources/PartialSheet/Public/View+PartialSheet.swift
+++ b/Sources/PartialSheet/Public/View+PartialSheet.swift
@@ -47,6 +47,7 @@ public extension View {
                                      iPhoneStyle: PSIphoneStyle = .defaultStyle(),
                                      iPadMacStyle: PSIpadMacStyle = .defaultStyle(),
                                      slideAnimation: PSSlideAnimation? = nil,
+                                     dragGestureSupported: Bool = true,
                                      @ViewBuilder content: @escaping () -> Content) -> some View {
         PSManagerWrapper(
             isPresented: isPresented,
@@ -54,6 +55,7 @@ public extension View {
             iPhoneStyle: iPhoneStyle,
             iPadMacStyle: iPadMacStyle,
             slideAnimation: slideAnimation,
+            dragGestureSupported: dragGestureSupported,
             content: content,
             parent: self
         )


### PR DESCRIPTION
## This is mentioned in https://github.com/AndreaMiotto/PartialSheet/issues/65. To be accurate, it's here

>>>I have looked a bit more into it and it is indeed the dragGesture that takes over the whole view. In some cases it can be fixed by just adding an onTapGesture {} to your view/button/picker but this does not work the DatePicker - then buttons stops to work.

## How to reproduce

Use the builtin example `DatePickerExample` and update

```swift
DatePicker("Date", selection: $date)
```

to 

```swift
DatePicker("Date", selection: $date)
                    .datePickerStyle(.graphical)
```


https://user-images.githubusercontent.com/103400893/176579938-a6497256-bf4f-4982-a5ee-e857e49f9d00.mp4



