### PR TITLE
Fix bug where using a segmented picker within a PartialSheet leads to unresponsive picker.

### DIFF
--- a/Sources/PartialSheet/PartialSheet/PSViewModifier.swift
+++ b/Sources/PartialSheet/PartialSheet/PSViewModifier.swift
@@ -246,7 +246,6 @@ extension PartialSheet {
                 .cornerRadius(iPhoneStyle.cornerRadius)
                 .shadow(color: Color(.sRGBLinear, white: 0, opacity: 0.13), radius: 10.0)
                 .offset(y: self.sheetPosition)
-                .onTapGesture {}
                 .gesture(drag)
             }
         }


### PR DESCRIPTION
Fix bug where using a segmented picker within a PartialSheet leads to unresponsive picker.

Remove call to onTapGesture method in iPhoneSheet builder.
As pointed out by @ajevans99, SwiftUI seems to have trouble handling segmented pickers correctly if an onTapGesture method is added to the view that contains the picker.
In this case of the iPhone sheet buider, the onTapGesture method call can safely be deleted since it was hardcoded to execute an empty closure.
Removing the call should therefore not have any effect except for solving the mentioned bug.