### PR TITLE
Bugfix PartailSheet height adjustment when keyboard is shown

### DIFF
--- a/Sources/PartialSheet/PartialSheet/PSViewModifier.swift
+++ b/Sources/PartialSheet/PartialSheet/PSViewModifier.swift
@@ -61,7 +61,7 @@ struct PartialSheet: ViewModifier {
     private var sheetPosition: CGFloat {
         if self.manager.isPresented {
             let topInset = safeAreaInsets.top
-            let position = self.topAnchor + self.dragOffset - self.keyboardOffset
+            let position = self.topAnchor + self.dragOffset
             
             if position < topInset {
                 return topInset


### PR DESCRIPTION
Co-Authored-By: @adrianhartanto004
Co-Authored-By: @naufalazzaahid

# Background
Fix calculate sheetPosition when keyboard is shown with a text field

# Approach
1. Remove subtracting `self.keyboardOffset` on calculating sheetPosition `position`

# Video
- Before

https://user-images.githubusercontent.com/50439894/212048871-30d46f02-1414-4289-9c1b-d9d4e0710920.mp4

- After

https://user-images.githubusercontent.com/50439894/212049759-c45980b2-867f-4db2-910a-53fef5f25b80.mp4

# Known Issue
- https://github.com/AndreaMiotto/PartialSheet/issues/151
