### PR TITLE
Accounts for Drag being Cancelled

### DIFF
--- a/Sources/PartialSheet/PartialSheet/PSViewModifier.swift
+++ b/Sources/PartialSheet/PartialSheet/PSViewModifier.swift
@@ -25,6 +25,8 @@ struct PartialSheet: ViewModifier {
     
     /// The offset for the drag gesture
     @State var dragOffset: CGFloat = 0
+    
+    @GestureState var isDetectingDrag: Bool = false
 
     /// The rect containing the presenter
     @State private var presenterContentRect: CGRect = .zero
@@ -248,6 +250,13 @@ extension PartialSheet {
                 .offset(y: self.sheetPosition)
                 .onTapGesture {}
                 .gesture(drag)
+                .onChange(of: isDetectingDrag) { newValue in
+                    if newValue == false {
+                        withAnimation(manager.slideAnimation.defaultSlideAnimation) {
+                            dragOffset = 0
+                        }
+                    }
+                }
             }
         }
     }

--- a/Sources/PartialSheet/PartialSheet/PartialSheet+DragGesture.swift
+++ b/Sources/PartialSheet/PartialSheet/PartialSheet+DragGesture.swift
@@ -10,10 +10,13 @@ import SwiftUI
 
 extension PartialSheet {
     /// Create a new **DragGesture** with *updating* and *onEndend* func
-    func dragGesture() -> _EndedGesture<_ChangedGesture<DragGesture>> {
+    func dragGesture() -> GestureStateGesture<_EndedGesture<_ChangedGesture<DragGesture>>, Bool> {
         DragGesture(minimumDistance: 0.1, coordinateSpace: .local)
             .onChanged(onDragChanged)
             .onEnded(onDragEnded)
+            .updating($isDetectingDrag) { value, state, transaction in
+                state = true
+            }
     }
     
     private func onDragChanged(drag: DragGesture.Value) {


### PR DESCRIPTION
Fixes an issue where the dragOffset doesn't reset when the drag is cancelled.
This is because onDragEnded doesn't get called.

Bug Details:
To test the bug, open a partial sheet. While dragging it up, lock your phone. It should stay stuck. 
This also happens when a partial sheet is open and you swipe up from the home screen as it detects a drag.