### PR TITLE
Add onDismiss closure to public ViewModifier

### DIFF
--- a/PartialSheet-Example/Shared/Examples/BaseExample.swift
+++ b/PartialSheet-Example/Shared/Examples/BaseExample.swift
@@ -23,8 +23,13 @@ struct BasicExample: View {
                 .padding()
             Spacer()
         }
-        .partialSheet(isPresented: $isSheetPresented,
-                      content: SheetView.init)
+        .partialSheet(
+            isPresented: $isSheetPresented,
+            onDismiss: {
+                print("On Dismiss Called")
+            },
+            content: SheetView.init
+        )
         .navigationBarTitle("Basic Example")
         .navigationViewStyle(StackNavigationViewStyle())
     }

--- a/Sources/PartialSheet/PartialSheet/PSManagerWrapper.swift
+++ b/Sources/PartialSheet/PartialSheet/PSManagerWrapper.swift
@@ -19,6 +19,7 @@ struct PSManagerWrapper<Parent: View, SheetContent: View>: View {
     let slideAnimation: PSSlideAnimation?
     let content: () -> SheetContent
     let parent: Parent
+    var onDismiss: (() -> Void)?
     
     var body: some View {
         parent
@@ -33,7 +34,10 @@ struct PSManagerWrapper<Parent: View, SheetContent: View>: View {
             iPadMacStyle: iPadMacStyle,
             slideAnimation: slideAnimation,
             content: content,
-            onDismiss: { self.isPresented = false}
+            onDismiss: {
+                self.isPresented = false
+                onDismiss?()
+            }
         )
     }
     

--- a/Sources/PartialSheet/Public/View+PartialSheet.swift
+++ b/Sources/PartialSheet/Public/View+PartialSheet.swift
@@ -47,6 +47,7 @@ public extension View {
                                      iPhoneStyle: PSIphoneStyle = .defaultStyle(),
                                      iPadMacStyle: PSIpadMacStyle = .defaultStyle(),
                                      slideAnimation: PSSlideAnimation? = nil,
+                                     onDismiss: (() -> Void)? = nil,
                                      @ViewBuilder content: @escaping () -> Content) -> some View {
         PSManagerWrapper(
             isPresented: isPresented,
@@ -55,7 +56,8 @@ public extension View {
             iPadMacStyle: iPadMacStyle,
             slideAnimation: slideAnimation,
             content: content,
-            parent: self
+            parent: self,
+            onDismiss: onDismiss
         )
     }
 }

--- a/Sources/PartialSheet/Public/View+PartialSheet.swift
+++ b/Sources/PartialSheet/Public/View+PartialSheet.swift
@@ -40,6 +40,7 @@ public extension View {
      - parameter iPhoneStyle: The Partial Sheet's style for iPhone
      - parameter iPadMacStyle: The Partial Sheet's style for iPad and Mac
      - parameter slideAnimation: The custon animation for the slide in / out of the  Partial Sheet
+     - parameter onDismiss: Allows presenter to call function when Partial Sheet is dismissed. Defaults to nil.
      - parameter content: The content of the Partial Sheet.
      */
     func partialSheet<Content: View>(isPresented: Binding<Bool>,


### PR DESCRIPTION
Iterations prior to the 3.0 variant of the framework provided an `onDismiss` closure. 
3.0+ removed public ability to set this parameter despite the property existing internally.
This change adds `onDismiss` back to the public facing `ViewModifier`.