### PR TITLE
Fixed a bug with no view due to the SwiftUI view lifecycle.

### DIFF
--- a/Sources/PartialSheet/PartialSheet/PSManager.swift
+++ b/Sources/PartialSheet/PartialSheet/PSManager.swift
@@ -16,7 +16,7 @@ import SwiftUI
  contentView.environmentObject(sheetManager)
  ```
  */
-class PSManager: ObservableObject {
+public class PSManager: ObservableObject {
     
     /// Published var to present or hide the partial sheet
     @Published var isPresented: Bool = false {
@@ -50,7 +50,7 @@ class PSManager: ObservableObject {
     var slideAnimation: PSSlideAnimation
 
     
-    init() {
+    public init() {
         content = EmptyView().eraseToAnyView()
         slideAnimation = PSSlideAnimation()
     }

--- a/Sources/PartialSheet/PartialSheet/PSManagerWrapper.swift
+++ b/Sources/PartialSheet/PartialSheet/PSManagerWrapper.swift
@@ -24,6 +24,7 @@ struct PSManagerWrapper<Parent: View, SheetContent: View>: View {
     var body: some View {
         parent
             .onChange(of: isPresented, perform: {_ in updateContent() })
+            .task { updateContent() }
     }
     
     private func updateContent() {

--- a/Sources/PartialSheet/Public/View+PartialSheet.swift
+++ b/Sources/PartialSheet/Public/View+PartialSheet.swift
@@ -27,8 +27,17 @@ public extension View {
      }
      ```
      */
-    func attachPartialSheetToRoot() -> some View {
-        let sheetManager: PSManager = PSManager()
+    func attachPartialSheetToRoot(manager: PSManager? = nil) -> some View {
+        let manager = {
+           if let manager {
+               return manager
+           } else {
+               return PSManager()
+           }
+        }() 
+        
+        let sheetManager: PSManager = manager
+        
         return self
             .modifier(PartialSheet())
             .environmentObject(sheetManager)


### PR DESCRIPTION
## Problem 1
**as-is)**
The Partial Sheet does not work in the following code:
```
struct ContentView: View {
  var body: some View {
    VStack {
      
    }
    .partialSheet(isPresented: .constant(true)) {
      Text("Hello World")
    }
    .attachPartialSheetToRoot()
  }
}
```

The reason it doesn’t work can be identified in this code:
```
struct PSManagerWrapper<Parent: View, SheetContent: View>: View {
    ...
    var body: some View {
        parent
            .onChange(of: isPresented, perform: {_ in updateContent() })
    }
    ...
}
```
Since 'updateContent()' only triggers when the value of 'isPresented' changes, if the initial value is true, the screen does not update.

**to-be)**
Modifying the code as below allows the initial value to be reflected correctly:
```
struct PSManagerWrapper<Parent: View, SheetContent: View>: View {
    ...
    var body: some View {
        parent
            .onChange(of: isPresented, perform: {_ in updateContent() })
            .task { updateContent() }
    }
    ...
}
```


## Problem 2
**as-is)**
The view disappears when the “Source of Truth” value changes, as shown below:
```
class SampleModel: ObservableObject {
  @Published var candidateChannelList: [String] = []
  
  func updateChannels() {
    candidateChannelList = ["Channel 1", "Channel 2", "Channel 3"]
  }
}

struct ContentView: View {
  @State private var isSheetPresented = false
  @StateObject private var sampleModel = SampleModel()
  
  var body: some View {
    VStack {
      Button("Show Partial Sheet") {
        isSheetPresented = true
      }
    }
    .partialSheet(isPresented: $isSheetPresented) {
      FeedChannelSelectorView(sampleModel: sampleModel, isPresented: $isSheetPresented)
    }
    .attachPartialSheetToRoot()
  }
}

struct FeedChannelSelectorView: View {
  @ObservedObject var sampleModel: SampleModel
  @Binding var isPresented: Bool
  
  var body: some View {
    VStack {
      HStack {
        Spacer()
        Button("Close") {
          isPresented = false
        }
        .padding()
      }
      
      Button(action: {
        sampleModel.updateChannels()
      }, label: {
        Text("RequestUpdate")
      })
      
      Text("Select a Channel")
        .font(.title)
        .padding(.bottom, 10)
      
      List(sampleModel.candidateChannelList, id: \.self) { channel in
        Text(channel)
          .onTapGesture {
            print("\(channel) selected")
            isPresented = false
          }
      }
    }
    .padding()
    .background(Color.white)
    .cornerRadius(10)
  }
}
```

We can see why the view disappears by looking at the following code:
```
public class PSManager: ObservableObject {
    
    /// Published var to present or hide the partial sheet
    @Published var isPresented: Bool = false {
        didSet {
            if !isPresented {
                DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) { [weak self] in
                    self?.content = EmptyView().eraseToAnyView()
                    self?.onDismiss = nil
                }
            }
        }
    }
    ...
```
The PSManager class has its own @Published property, isPresented. The Partial Sheet operates based on this isPresented value. When attachPartialSheetToRoot() is called, a new instance of PSManager is created:
```
public extension View {
    ...
    func attachPartialSheetToRoot() -> some View {
        let sheetManager: PSManager = PSManager()
        return self
            .modifier(PartialSheet())
            .environmentObject(sheetManager)
    }
    ...
```
Each time the “Source of Truth” changes, the view seems to be redrawn, causing a new PSManager to be created.

**to-be)**
To solve this, I modified attachPartialSheetToRoot() to allow an externally managed PSManager instance. Although this is not ideal, it provides a temporary solution:
```
public extension View {
    ...
    func attachPartialSheetToRoot(manager: PSManager? = nil) -> some View {
        let manager = {
           if let manager {
               return manager
           } else {
               return PSManager()
           }
        }() 
        
        let sheetManager: PSManager = manager
        
        return self
            .modifier(PartialSheet())
            .environmentObject(sheetManager)
    }
    ...
```
This requires making PSManager public to manage its instances externally.

```
public class PSManager: ObservableObject {
    ...
    public init() {
        content = EmptyView().eraseToAnyView()
        slideAnimation = PSSlideAnimation()
    }
    ...
}
```
Then, the ContentView is updated as follows:
```
class SampleModel: ObservableObject {
  @Published var candidateChannelList: [String] = []
  
  func updateChannels() {
    candidateChannelList = ["Channel 1", "Channel 2", "Channel 3"]
  }
}

struct ContentView: View {
  @State private var isSheetPresented = false
  @StateObject private var sampleModel = SampleModel()
  @StateObject private var psManager = PSManager()
  
  var body: some View {
    VStack {
      Button("Show Partial Sheet") {
        isSheetPresented = true
      }
    }
    .partialSheet(isPresented: $isSheetPresented) {
      FeedChannelSelectorView(sampleModel: sampleModel, isPresented: $isSheetPresented)
    }
    .attachPartialSheetToRoot(manager: psManager)
  }
}

struct FeedChannelSelectorView: View {
  @ObservedObject var sampleModel: SampleModel
  @Binding var isPresented: Bool
  
  var body: some View {
    VStack {
      HStack {
        Spacer()
        Button("Close") {
          isPresented = false
        }
        .padding()
      }
      
      Button(action: {
        sampleModel.updateChannels()
      }, label: {
        Text("Refresh")
      })
      
      Text("Select a Channel")
        .font(.title)
        .padding(.bottom, 10)
      
      List(sampleModel.candidateChannelList, id: \.self) { channel in
        Text(channel)
          .onTapGesture {
            print("\(channel) selected")
            isPresented = false
          }
      }
    }
    .padding()
    .background(Color.white)
    .cornerRadius(10)
  }
}
```
If you apply the above modifications, it should work as intended. Let me know if you have suggestions for a better approach!